### PR TITLE
feat: prevent realm name clash with Lighthouse

### DIFF
--- a/src/ports/realm.ts
+++ b/src/ports/realm.ts
@@ -39,6 +39,10 @@ export async function createRealmComponent(
   let realmName = ''
 
   async function start() {
+    // TODO implement realm name. The flow has been cut to prevent race conditions between this service and Lighthouse
+    realmName = ''
+    return
+
     const CURRENT_ETH_NETWORK = (await config.getString('ETH_NETWORK')) ?? DEFAULT_ETH_NETWORK
 
     // Keeping LIGHTHOUSE_NAMES for retrocompatibility


### PR DESCRIPTION
As both Lighthouse and this service are trying to claim some realm name, they can run into race conditions, where they try to claim more than the available names. This is a temporary measure to prevent service unavailability in production